### PR TITLE
Changed cloc from long to int on the FileMetrics case class. 

### DIFF
--- a/src/main/scala/codacy/docker/api/metrics/Metrics.scala
+++ b/src/main/scala/codacy/docker/api/metrics/Metrics.scala
@@ -3,7 +3,7 @@ package codacy.docker.api.metrics
 case class FileMetrics(filename: String,
                        complexity: Option[Int] = None,
                        loc: Option[Int] = None,
-                       cloc: Option[Long] = None,
+                       cloc: Option[Int] = None,
                        nrMethods: Option[Int] = None,
                        nrClasses: Option[Int] = None,
                        lineComplexities: Set[LineComplexity] = Set.empty)


### PR DESCRIPTION
It doesn't make sense for it to be a long since it is an int on the database.