### PR TITLE
Add Crystal support

### DIFF
--- a/src/main/scala/com/codacy/plugins/api/languages/Language.scala
+++ b/src/main/scala/com/codacy/plugins/api/languages/Language.scala
@@ -76,6 +76,7 @@ object Languages {
                                PHP,
                                Python,
                                Ruby,
+                               Crystal,
                                Java,
                                CoffeeScript,
                                Swift,
@@ -251,6 +252,8 @@ object Languages {
   case object HTML extends Language(extensions = Set(".html"))
 
   case object Groovy extends Language(extensions = Set(".groovy"))
+
+  case object Crystal extends Language(extensions = Set(".cr"))
 
   // Others
 


### PR DESCRIPTION
Hey everyone.

This PR adds support for Crystal programming language:

* https://crystal-lang.org/
* https://crystal-lang.org/docs/
* https://github.com/crystal-lang/crystal

### Background

I started working on integrating Ameba static anaysis tool for Crystal to Codacy:

* https://github.com/veelenga/ameba
* https://github.com/veelenga/codacy-ameba

But noticed I can't run [codacy-plugins-test](https://github.com/codacy/codacy-plugins-test) because the language itself is not supported yet.