### PR TITLE
breaking: Update to the format used by the documented format CY-3490

### DIFF
--- a/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Result.scala
+++ b/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Result.scala
@@ -22,14 +22,14 @@ object Result {
     override def toString: String = value
   }
 
-  case class Issue(file: Source.File,
+  case class Issue(filename: Source.File,
                    message: Result.Message,
                    patternId: Pattern.Id,
                    line: Source.Line,
                    suggestion: Option[Suggestion] = None)
       extends Result
 
-  case class FileError(file: Source.File, message: Option[ErrorMessage]) extends Result
+  case class FileError(filename: Source.File, message: Option[ErrorMessage]) extends Result
 
   type Level = Level.Value
 

--- a/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Tool.scala
+++ b/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Tool.scala
@@ -29,6 +29,4 @@ object Tool {
                                  files: Option[Set[Source.File]],
                                  options: Option[Map[Options.Key, Options.Value]])
 
-  case class CodacyAlternativeConfiguration(enabled: Boolean, include_paths: Option[Set[Source.File]])
-
 }


### PR DESCRIPTION
This PR updates the format used by Scala tools to match the format we use in other languages.
The format is already understood by codacy-plugins so it's safe to update without any particular problem.
After there are no tools using `file` instead of `filename`, we can stop reading the file format in codacy-plugins.