### PR TITLE
Language: add '.mjs' to Javascript extension set

### DIFF
--- a/src/main/scala/com/codacy/plugins/api/languages/Language.scala
+++ b/src/main/scala/com/codacy/plugins/api/languages/Language.scala
@@ -99,7 +99,7 @@ object Languages {
                                Terraform)
 
   // Support startdate: always
-  case object Javascript extends Language(extensions = Set(".js", ".jsx", ".jsm", ".vue"))
+  case object Javascript extends Language(extensions = Set(".js", ".jsx", ".jsm", ".mjs", ".vue"))
 
   case object Scala extends Language(extensions = Set(".scala"))
 

--- a/src/test/scala/com.codacy.plugins.api.languages/LanguageSpec.scala
+++ b/src/test/scala/com.codacy.plugins.api.languages/LanguageSpec.scala
@@ -28,6 +28,7 @@ class LanguageSpec extends Specification with NoLanguageFeatures {
       Languages.forPath("src/main/scala/com/codacy/File1.scala") should beEqualTo(Some(Languages.Scala))
       Languages.forPath("src/main/scala/com/codacy/File1.sc", List((Languages.Scala, Seq(".sc")))) should beEqualTo(
         Some(Languages.Scala))
+      Languages.forPath("src/File3.mjs") should beEqualTo(Some(Languages.Javascript))
     }
   }
 }


### PR DESCRIPTION
The ".mjs" extension is used for ECMAScript modules.

See:

- https://nodejs.org/api/esm.html#esm_enabling
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#aside_%E2%80%94_.mjs_versus_.js
- https://v8.dev/features/modules#mjs