### PR TITLE
Add .mts as valid TypeScript extension

### DIFF
--- a/src/main/scala/com/codacy/plugins/api/languages/Language.scala
+++ b/src/main/scala/com/codacy/plugins/api/languages/Language.scala
@@ -139,7 +139,7 @@ object Languages {
   case object Shell extends Language(extensions = Set(".sh", ".bash"))
 
   // Support startdate: 24 November 2016
-  case object TypeScript extends Language(extensions = Set(".ts", ".tsx"))
+  case object TypeScript extends Language(extensions = Set(".ts", ".mts", ".tsx"))
 
   // Support startdate: December 2016
   case object Dockerfile extends Language(extensions = Set(".dockerfile"), files = Set("Dockerfile"))


### PR DESCRIPTION
Analogous to #66 

Fixes codacy/codacy-coverage-reporter#446