### PR TITLE
TSQLLint-add-sql-extension-TS-543

### DIFF
--- a/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/languages/Language.scala
+++ b/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/languages/Language.scala
@@ -145,15 +145,14 @@ object Languages {
   case object Dockerfile extends Language(extensions = Set(".dockerfile"), files = Set("Dockerfile"))
 
   // Support startdate: January 2017
-  case object SQL extends Language(extensions = Set.empty[String])
+  case object SQL extends Language(extensions = Set(".sql"))
 
   // Support startdate: November 2019
   case object TSQL extends Language(extensions = Set(".tsql"))
 
   case object PLSQL
       extends Language(
-        extensions = Set(".sql", // Normal SQL
-                         ".trg", // Triggers
+        extensions = Set(".trg", // Triggers
                          ".prc",
                          ".fnc", // Standalone Procedures and Functions
                          ".pld", // Oracle*Forms


### PR DESCRIPTION
Add ".sql" extension to (a more generic) SQL Language so it can be used in 2 tools:
- TSQLLint
- SQLint