### PR TITLE
feat: Change language detection precendence

### DIFF
--- a/codacy-plugins-api/src/main/scala-2.13+/com/codacy/plugins/api/languages/LanguageImpl.scala
+++ b/codacy-plugins-api/src/main/scala-2.13+/com/codacy/plugins/api/languages/LanguageImpl.scala
@@ -40,12 +40,17 @@ private[languages] object LanguagesImpl {
     }
 
     filePath.split('/').lastOption.flatMap { filename =>
-      languageByCustomExtension.collectFirst { case (ext, lang) if filename.endsWith(ext) => lang }.orElse {
-        (for {
-          extension <- filename.split('.').lastOption
-          dottedExtension = s".$extension"
-        } yield languageByExtension.get(dottedExtension.toLowerCase)).flatten
-      }.orElse(languageByFilename.get(filename.toLowerCase))
+      languageByFilename
+        .get(filename.toLowerCase)
+        .orElse {
+          languageByCustomExtension.collectFirst { case (ext, lang) if filename.endsWith(ext) => lang }
+        }
+        .orElse {
+          (for {
+            extension <- filename.split('.').lastOption
+            dottedExtension = s".$extension"
+          } yield languageByExtension.get(dottedExtension.toLowerCase)).flatten
+        }
     }
   }
 }

--- a/codacy-plugins-api/src/main/scala-2.13-/com/codacy/plugins/api/languages/LanguageImpl.scala
+++ b/codacy-plugins-api/src/main/scala-2.13-/com/codacy/plugins/api/languages/LanguageImpl.scala
@@ -40,12 +40,17 @@ private[languages] object LanguagesImpl {
     }
 
     filePath.split('/').lastOption.flatMap { filename =>
-      languageByCustomExtension.collectFirst { case (ext, lang) if filename.endsWith(ext) => lang }.orElse {
-        (for {
-          extension <- filename.split('.').lastOption
-          dottedExtension = s".$extension"
-        } yield languageByExtension.get(dottedExtension.toLowerCase)).flatten
-      }.orElse(languageByFilename.get(filename.toLowerCase))
+      languageByFilename
+        .get(filename.toLowerCase)
+        .orElse {
+          languageByCustomExtension.collectFirst { case (ext, lang) if filename.endsWith(ext) => lang }
+        }
+        .orElse {
+          (for {
+            extension <- filename.split('.').lastOption
+            dottedExtension = s".$extension"
+          } yield languageByExtension.get(dottedExtension.toLowerCase)).flatten
+        }
     }
   }
 }

--- a/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/languages/Language.scala
+++ b/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/languages/Language.scala
@@ -107,7 +107,7 @@ object Languages {
 
   case object PHP extends Language(extensions = Set(".php"), files = Set("composer.lock"))
 
-  case object Python extends Language(extensions = Set(".py"), files = Set("Pipfile.lock", "requirements.txt"))
+  case object Python extends Language(extensions = Set(".py"), files = Set("requirements.txt", "Pipfile.lock"))
 
   // Support startdate: 31 August 2015
   case object Ruby
@@ -126,7 +126,7 @@ object Languages {
                                    "Vagabondfile",
                                    "Fastfile"))
 
-  case object Java extends Language(extensions = Set(".java"))
+  case object Java extends Language(extensions = Set(".java"), files = Set("gradle.lockfile", "pom.xml"))
 
   case object CoffeeScript extends Language(extensions = Set(".coffee"))
 
@@ -180,7 +180,7 @@ object Languages {
   case object LESS extends Language(extensions = Set(".less"))
 
   // Support startdate: March 2017
-  case object Go extends Language(extensions = Set(".go"))
+  case object Go extends Language(extensions = Set(".go"), files = Set("go.mod", "go.sum"))
 
   case object JSP extends Language(extensions = Set(".jsp"))
 
@@ -233,7 +233,7 @@ object Languages {
   case object Terraform extends Language(extensions = Set(".tf"))
 
   // Support startdate: January 2022
-  case object Dart extends Language(extensions = Set(".dart"))
+  case object Dart extends Language(extensions = Set(".dart"), files = Set("pubspec.lock"))
 
   // Support startdate: October 2023
   case object Rust extends Language(extensions = Set(".rs", ".rlib"), files = Set("Cargo.lock"))


### PR DESCRIPTION
The order by which we discover language from filename should be reversed to:
- by matching language defined filenames list (more specific)
- by matching custom extensions list set by user
- finally by matching language defined extensions list (more broad)

It's also important in the scope of dependency analysis: https://codacy.atlassian.net/browse/CY-7309 