### PR TITLE
fix: Make SBOM component licenses optional

### DIFF
--- a/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Result.scala
+++ b/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Result.scala
@@ -97,7 +97,7 @@ object Result {
                          version: Option[String],
                          purl: Option[String],
                          properties: List[Property],
-                         licenses: List[LicenseWrapper])
+                         licenses: Option[List[LicenseWrapper]])
 
     object Component {
       type Type = Type.Value


### PR DESCRIPTION
This field might not exist in the tool SBOM result and it is better modeled as an Option.