### PR TITLE
fix: Remove subcategory requirement for `Specification` [CF-1607]

### DIFF
--- a/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Pattern.scala
+++ b/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Pattern.scala
@@ -35,9 +35,7 @@ object Pattern {
                            scanType: Option[ScanType] = Option.empty,
                            parameters: Set[Parameter.Specification] = Set.empty,
                            languages: Set[Language] = Set.empty,
-                           enabled: Boolean = false) {
-    require(subcategory.isEmpty || category == Category.Security, "Security is the only category having subcategories")
-  }
+                           enabled: Boolean = false) {}
 
   type Category = Category.Value
   object Category extends Enumeration {


### PR DESCRIPTION
It's possible for categories other than 'Security' to have subcategories.