### PR TITLE
fix: Remove runtime check for subcategories

### DIFF
--- a/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Pattern.scala
+++ b/codacy-plugins-api/src/main/scala/com/codacy/plugins/api/results/Pattern.scala
@@ -35,9 +35,7 @@ object Pattern {
                            scanType: Option[ScanType] = Option.empty,
                            parameters: Set[Parameter.Specification] = Set.empty,
                            languages: Set[Language] = Set.empty,
-                           enabled: Boolean = false) {
-    require(subcategory.isEmpty || category == Category.Security, "Security is the only category having subcategories")
-  }
+                           enabled: Boolean = false)
 
   type Category = Category.Value
   object Category extends Enumeration {


### PR DESCRIPTION
The original adding of the require was not justified so we are removing it. It it causing problems as there are some changes on some Patterns (with AI augment) that some patterns that now are not category Security and still have subcategories

@lolgab do you have any ideia why it was added as part of https://github.com/codacy/codacy-plugins-api/pull/46 or what it could imply?